### PR TITLE
Fixes paths into config - ready for merge

### DIFF
--- a/energy_demand/basic/basic_functions.py
+++ b/energy_demand/basic/basic_functions.py
@@ -6,27 +6,6 @@ from collections import defaultdict
 import numpy as np
 from pyproj import Proj, transform
 
-def convert_config_to_correct_type(config):
-    """Convert config types into correct types
-    """
-    out_dict = defaultdict(dict)
-
-    for path in config['PATHS']:
-        out_dict['PATHS'][path] = config.get('PATHS', path)
-
-    for path in config['DATA_PATHS']:
-        out_dict['DATA_PATHS'][path] = config.get('DATA_PATHS', path)
-
-    for config_section in config['CONFIG']:
-        out_dict['CONFIG'][config_section] = config.getint('CONFIG', config_section)
-
-    for criteria in config['CRITERIA']:
-        if criteria == 'reg_selection_csv_name':
-            out_dict['CRITERIA'][criteria] = config.get('CRITERIA', criteria)
-        else:
-            out_dict['CRITERIA'][criteria] = config.getboolean('CRITERIA', criteria)
-
-    return dict(out_dict)
 
 def dict_depth(dictionary):
     """Get depth of nested dict

--- a/energy_demand/basic/basic_functions.py
+++ b/energy_demand/basic/basic_functions.py
@@ -14,6 +14,9 @@ def convert_config_to_correct_type(config):
     for path in config['PATHS']:
         out_dict['PATHS'][path] = config.get('PATHS', path)
 
+    for path in config['DATA_PATHS']:
+        out_dict['DATA_PATHS'][path] = config.get('DATA_PATHS', path)
+
     for config_section in config['CONFIG']:
         out_dict['CONFIG'][config_section] = config.getint('CONFIG', config_section)
 

--- a/energy_demand/read_write/data_loader.py
+++ b/energy_demand/read_write/data_loader.py
@@ -464,9 +464,58 @@ def floor_area_virtual_dw(
     return dict(rs_floorarea), dict(ss_floorarea_sector_by), service_building_count, rs_regions_without_floorarea, list(ss_regions_without_floorarea)
 
 
+def read_config_file(config_file_path):
+    """Reads all sections of a configuration file
+
+    Arguments
+    ---------
+    config_file_path : str
+        Absolute path to the configuration file
+
+    Returns
+    -------
+    dict
+        A nested dictionary containing all the paths
+
+    """
+    config = configparser.ConfigParser()
+    config.read(config_file_path)
+
+    return convert_config_to_correct_type(config)
+
+
+def convert_config_to_correct_type(config):
+    """Convert config types into correct types
+    """
+    out_dict = defaultdict(dict)
+
+    for path in config['PATHS']:
+        out_dict['PATHS'][path] = config.get('PATHS', path)
+
+    for path in config['DATA_PATHS']:
+        out_dict['DATA_PATHS'][path] = config.get('DATA_PATHS', path)
+
+    for path in config['CONFIG_DATA']:
+        out_dict['CONFIG_DATA'][path] = config.get('CONFIG_DATA', path)
+
+    for path in config['RESULT_DATA']:
+        out_dict['RESULT_DATA'][path] = config.get('RESULT_DATA', path)
+
+    for config_section in config['CONFIG']:
+        out_dict['CONFIG'][config_section] = config.getint('CONFIG', config_section)
+
+    for criteria in config['CRITERIA']:
+        if criteria == 'reg_selection_csv_name':
+            out_dict['CRITERIA'][criteria] = config.get('CRITERIA', criteria)
+        else:
+            out_dict['CRITERIA'][criteria] = config.getboolean('CRITERIA', criteria)
+
+    return dict(out_dict)
+
+
 def get_local_paths(config_file_path):
     """Create all local paths
-    
+
     Local paths with data used for model config, raw data and process data
 
     Arguments
@@ -480,33 +529,33 @@ def get_local_paths(config_file_path):
         All local paths used in model
     """
     paths = [
-        'local_path_datafolder',
-        'path_strategy_vars',
-        'path_population_data_for_disaggregation_LAD',
-        'path_population_data_for_disaggregation_MSOA',
-        'folder_raw_carbon_trust',
-        'folder_path_weater_stations',
-        'path_floor_area_virtual_stock_by',
-        'path_assumptions_db',
-        'data_processed',
-        'lad_shapefile',
-        'path_post_installation_data',
-        'weather_data',
-        'load_profiles',
-        'rs_load_profile_txt',
-        'ss_load_profile_txt',
-        'yaml_parameters',
-        'yaml_parameters_constrained',
-        'yaml_parameters_keynames_constrained',
-        'yaml_parameters_keynames_unconstrained',
-        'yaml_parameters_scenario']
+        ('local_path_datafolder', 'str')
+        ('path_strategy_vars', 'str')
+        ('path_population_data_for_disaggregation_LAD', 'str')
+        ('path_population_data_for_disaggregation_MSOA', 'str')
+        ('folder_raw_carbon_trust', 'str')
+        ('folder_path_weater_stations', 'str')
+        ('path_floor_area_virtual_stock_by', 'str')
+        ('path_assumptions_db', 'str')
+        ('data_processed', 'str')
+        ('lad_shapefile', 'str')
+        ('path_post_installation_data', 'str')
+        ('weather_data', 'str')
+        ('load_profiles', 'str')
+        ('rs_load_profile_txt', 'str')
+        ('ss_load_profile_txt', 'str')
+        ('yaml_parameters', 'str')
+        ('yaml_parameters_constrained', 'str')
+        ('yaml_parameters_keynames_constrained', 'str')
+        ('yaml_parameters_keynames_unconstrained', 'str')
+        ('yaml_parameters_scenario', 'str')]
 
     return _read_config_file_section('DATA_PATHS', config_file_path, paths)
 
 
 def _read_config_file_section(section, config_file_path, items):
     """
-    
+
     Arguments
     ---------
     section : str
@@ -528,46 +577,48 @@ def _read_config_file_section(section, config_file_path, items):
     data_paths = {}
     config = configparser.ConfigParser()
     config.read(config_file_path)
-    for item in items:
+    for item, item_type in items:
         try:
-            data_paths[item] = config.get(section, item)
+            if item_type == 'str':
+                data_paths[item] = config.get(section, item)
+            elif item_type == 'bool':
+                data_paths[item] = config.getboolean(section, item)
+            elif item_type == 'int':
+                data_paths[item] = config.getint(section, item)
+
         except configparser.NoOptionError:
-            msg = "Option '{}' doesn't exist in section {} in {}"
+            msg = "Option '{}' doesn't exist in section '{}' in '{}'"
             raise ValueError(msg.format(item, section, config_file_path))
+        except configparser.NoSectionError:
+            msg = "Section '{}' doesn't exist in '{}'"
+            raise ValueError(msg.format(section, config_file_path))
     return data_paths
 
-def get_result_paths(path):
+
+def get_result_paths(config_file_path):
     """Load all result paths
 
     Arguments
     --------
-    path : str
-        Path to result folder
+    config_file_path : str
+        config_file_path to the wrapperconfig.ini configuration file
 
     Return
     -------
     paths : dict
         All result paths used in model
     """
-    paths = {
-        'data_results':
-            path,
-        'data_results_model_run_pop': os.path.join(
-            path, 'model_run_pop'),
-        'data_results_model_runs': os.path.join(
-            path, 'model_run_results_txt'),
-        'data_results_PDF': os.path.join(
-            path, 'PDF_results'),
-        'data_results_validation': os.path.join(
-            path, 'PDF_validation'),
-        'model_run_pop': os.path.join(
-            path, 'model_run_pop'),
-        'data_results_shapefiles': os.path.join(
-            path, 'spatial_results'),
-        'individual_enduse_lp': os.path.join(
-            path, 'individual_enduse_lp')}
+    paths = [
+        ('data_results_model_run_pop', 'str'),
+        ('data_results_model_runs', 'str'),
+        ('data_results_PDF', 'str'),
+        ('data_results_validation', 'str'),
+        ('model_run_pop', 'str'),
+        ('data_results_shapefiles', 'str'),
+        ('individual_enduse_lp', 'str')]
 
-    return paths
+    return _read_config_file_section('RESULT_DATA', config_file_path, paths)
+
 
 def load_paths(config_file_path):
     """Load all paths of the installed config data
@@ -583,37 +634,38 @@ def load_paths(config_file_path):
         Dictionary containing the paths to each datafile
     """
     paths = [
-        'path_main',
+        ('path_main', 'int'),
         # Path to all technologies
-        'path_technologies',
+        ('path_technologies', 'int'),
         # Paths to fuel raw data
-        'rs_fuel_raw',
-        'ss_fuel_raw',
-        'is_fuel_raw',
+        ('rs_fuel_raw', 'int'),
+        ('ss_fuel_raw', 'int'),
+        ('is_fuel_raw', 'int'),
         # Load profiles
-        'lp_rs',
+        ('lp_rs', 'int'),
         # Technologies load shapes
-        'path_hourly_gas_shape_resid',
-        'lp_elec_hp_dh',
-        'lp_all_microCHP_dh',
-        'path_shape_rs_cooling',
-        'path_shape_ss_cooling',
-        'lp_elec_storage_heating',
-        'lp_elec_secondary_heating',
+        ('path_hourly_gas_shape_resid', 'int'),
+        ('lp_elec_hp_dh', 'int'),
+        ('lp_all_microCHP_dh', 'int'),
+        ('path_shape_rs_cooling', 'int'),
+        ('path_shape_ss_cooling', 'int'),
+        ('lp_elec_storage_heating', 'int'),
+        ('lp_elec_secondary_heating', 'int'),
         # Census data
-        'path_employment_statistics',
+        ('path_employment_statistics', 'int'),
         # Validation datasets
-        'val_subnational_elec',
-        'val_subnational_elec_residential',
-        'val_subnational_elec_non_residential',
-        'val_subnational_elec_msoa_residential',
-        'val_subnational_elec_msoa_non_residential',
-        'val_subnational_gas',
-        'val_subnational_gas_residential',
-        'val_subnational_gas_non_residential',
-        'val_nat_elec_data']
+        ('val_subnational_elec', 'int'),
+        ('val_subnational_elec_residential', 'int'),
+        ('val_subnational_elec_non_residential', 'int'),
+        ('val_subnational_elec_msoa_residential', 'int'),
+        ('val_subnational_elec_msoa_non_residential', 'int'),
+        ('val_subnational_gas', 'int'),
+        ('val_subnational_gas_residential', 'int'),
+        ('val_subnational_gas_non_residential', 'int'),
+        ('val_nat_elec_data', 'int')]
 
     return _read_config_file_section('CONFIG_DATA', config_file_path, paths)
+
 
 def load_tech_profiles(
         tech_lp,

--- a/energy_demand/read_write/data_loader.py
+++ b/energy_demand/read_write/data_loader.py
@@ -20,6 +20,7 @@ from energy_demand.plotting import fig_lp
 from energy_demand.basic import basic_functions
 from energy_demand.read_write import narrative_related
 
+
 def print_closest_and_region(stations_as_dict, region_to_plot, closest_region):
     """Function used to test if the closest weather region is assigned
     """
@@ -51,12 +52,11 @@ def print_closest_and_region(stations_as_dict, region_to_plot, closest_region):
 
     plt.legend()
 
-def create_weather_station_map(
-        stations_as_dict,
-        fig_path,
-        path_shapefile=False
-    ):
-    """Plot the spatial disribution of the weather stations
+
+def create_weather_station_map(stations_as_dict,
+                               fig_path,
+                               path_shapefile=False):
+    """Plot the spatial distribution of the weather stations
 
     https://geopandas.readthedocs.io/en/latest/gallery/create_geopandas_from_pandas.html
 
@@ -112,6 +112,7 @@ def create_weather_station_map(
             station_infos.append(station_info)
 
         write_data.write_list_to_txt(fig_path, station_infos)
+
 
 def read_weather_stations_raw(path_to_csv):
     """Read in weather stations from csv file
@@ -462,64 +463,57 @@ def floor_area_virtual_dw(
 
     return dict(rs_floorarea), dict(ss_floorarea_sector_by), service_building_count, rs_regions_without_floorarea, list(ss_regions_without_floorarea)
 
-def get_local_paths(path):
+
+def get_local_paths(config_file_path):
     """Create all local paths
+    
+    Local paths with data used for model config, raw data and process data
 
     Arguments
     --------
-    path : str
-        Path of local folder with data used for model
+    config_file_path : str
+        config_file_path to the wrapperconfig.ini configuration file
 
     Return
     -------
-    paths : dict
+    data_paths : dict
         All local paths used in model
     """
-    paths = {
-        'local_path_datafolder': path,
 
-        # Path to user defined strategy vars
-        'path_strategy_vars': os.path.join(
-            path, 'energy_demand', '00_user_defined_variables'),
+    data_paths = {}
 
-        'path_population_data_for_disaggregation_LAD': os.path.join(
-            path, 'energy_demand', '_raw_data', 'J-population_disagg_by', 'uk_pop_principal_2015_2050.csv'), #ONS principal projection
-        'path_population_data_for_disaggregation_MSOA': os.path.join(
-            path, 'energy_demand', '_raw_data', 'J-population_disagg_by', 'uk_pop_principal_2015_2050_MSOA_lad.csv'), #ONS principal projection
-        'folder_raw_carbon_trust': os.path.join(
-            path, 'energy_demand', '_raw_data', "G_Carbon_Trust_advanced_metering_trial"),
-        'folder_path_weater_stations': os.path.join(
-            path, 'energy_demand', '_raw_data', 'A-temperature_data', 'cleaned_weather_stations.csv'),
-        'path_floor_area_virtual_stock_by': os.path.join(
-            path, 'energy_demand', '_raw_data', 'K-floor_area', 'floor_area_LAD_latest.csv'),
-        'path_assumptions_db': os.path.join(
-            path, 'energy_demand', '_processed_data', 'assumptions_from_db'),
-        'data_processed': os.path.join(
-            path, 'energy_demand', '_processed_data'),
-        'lad_shapefile': os.path.join(
-            path, 'energy_demand', '_raw_data', 'C_LAD_geography', 'same_as_pop_scenario', 'lad_2016_uk_simplified.shp'),
-        'path_post_installation_data': os.path.join(
-            path, 'energy_demand', '_processed_data'),
-        'weather_data': os.path.join(
-            path, 'energy_demand', '_raw_data', 'A-temperature_data', 'cleaned_weather_stations_data'),
-        'load_profiles': os.path.join(
-            path, 'energy_demand', '_processed_data', 'load_profiles'),
-        'rs_load_profile_txt': os.path.join(
-            path, 'energy_demand', '_processed_data', 'load_profiles', 'rs_submodel'),
-        'ss_load_profile_txt': os.path.join(
-            path, 'energy_demand', '_processed_data', 'load_profiles', 'ss_submodel'),
-        'yaml_parameters': os.path.join(
-            path, '..', 'config', 'yaml_parameters.yml'),
-        'yaml_parameters_constrained': os.path.join(
-            path, '..', 'config', 'yaml_parameters_constrained.yml'),
-        'yaml_parameters_keynames_constrained': os.path.join(
-            path, '..', 'config', 'yaml_parameters_keynames_constrained.yml'),
-        'yaml_parameters_keynames_unconstrained': os.path.join(
-            path, '..', 'config', 'yaml_parameters_keynames_unconstrained.yml'),
-        'yaml_parameters_scenario': os.path.join(
-            path, '..', 'config', 'yaml_parameters_scenario.yml')}
+    paths = [
+        'local_path_datafolder',
+        'path_strategy_vars',
+        'path_population_data_for_disaggregation_LAD',
+        'path_population_data_for_disaggregation_MSOA',
+        'folder_raw_carbon_trust',
+        'folder_path_weater_stations',
+        'path_floor_area_virtual_stock_by',
+        'path_assumptions_db',
+        'data_processed',
+        'lad_shapefile',
+        'path_post_installation_data',
+        'weather_data',
+        'load_profiles',
+        'rs_load_profile_txt',
+        'ss_load_profile_txt',
+        'yaml_parameters',
+        'yaml_parameters_constrained',
+        'yaml_parameters_keynames_constrained',
+        'yaml_parameters_keynames_unconstrained',
+        'yaml_parameters_scenario']
 
-    return paths
+    config = configparser.ConfigParser()
+    config.read(config_file_path)
+
+    for path in paths:
+        try:
+            data_paths[path] = config.get('DATA_PATHS', path)
+        except configparser.NoOptionError:
+            msg = "Option '{}' doesn't exist in section 'DATA_PATHS' in {}"
+            raise ValueError(msg.format(path, config_file_path))
+    return data_paths
 
 def get_result_paths(path):
     """Load all result paths

--- a/energy_demand/read_write/data_loader.py
+++ b/energy_demand/read_write/data_loader.py
@@ -479,9 +479,6 @@ def get_local_paths(config_file_path):
     data_paths : dict
         All local paths used in model
     """
-
-    data_paths = {}
-
     paths = [
         'local_path_datafolder',
         'path_strategy_vars',
@@ -504,15 +501,39 @@ def get_local_paths(config_file_path):
         'yaml_parameters_keynames_unconstrained',
         'yaml_parameters_scenario']
 
+    return _read_config_file_section('DATA_PATHS', config_file_path, paths)
+
+
+def _read_config_file_section(section, config_file_path, items):
+    """
+    
+    Arguments
+    ---------
+    section : str
+        Name of the section to read
+    config_file_path : str
+        Absolute path to the config file
+    items : list of str
+        A list of names of the config items to read
+
+    Returns
+    -------
+    dict
+        Keys are the item names
+
+    Raises
+    ------
+    ValueError if the configuration item does not exist in the file
+    """
+    data_paths = {}
     config = configparser.ConfigParser()
     config.read(config_file_path)
-
-    for path in paths:
+    for item in items:
         try:
-            data_paths[path] = config.get('DATA_PATHS', path)
+            data_paths[item] = config.get(section, item)
         except configparser.NoOptionError:
-            msg = "Option '{}' doesn't exist in section 'DATA_PATHS' in {}"
-            raise ValueError(msg.format(path, config_file_path))
+            msg = "Option '{}' doesn't exist in section {} in {}"
+            raise ValueError(msg.format(item, section, config_file_path))
     return data_paths
 
 def get_result_paths(path):

--- a/energy_demand/read_write/data_loader.py
+++ b/energy_demand/read_write/data_loader.py
@@ -706,12 +706,11 @@ def load_tech_profiles(
     tech_lp : dict
         Load profiles
     paths : dict
-        Paths
+        Path to open config data
     local_paths : dict
-        Local paths
+        Local data paths (private data downloaded from ftp)
     plot_tech_lp : bool
-        Criteria wheter individual tech lp are
-        saved as figure to separte folder
+        Criteria whether individual tech lp are saved as figure to separate folder
 
     Returns
     ------
@@ -726,7 +725,7 @@ def load_tech_profiles(
 
     # CHP load profile from Robert Sansom
     tech_lp['rs_lp_heating_CHP_dh'] = read_data.read_load_shapes_tech(
-        paths['lp_all_microCHP_dh'])
+        paths['lp_all_microchp_dh'])
 
     # Heat pump load profile from Love et al. (2017)
     tech_lp['rs_lp_heating_hp_dh'] = read_data.read_load_shapes_tech(

--- a/energy_demand/read_write/data_loader.py
+++ b/energy_demand/read_write/data_loader.py
@@ -569,79 +569,51 @@ def get_result_paths(path):
 
     return paths
 
-def load_paths(path):
+def load_paths(config_file_path):
     """Load all paths of the installed config data
 
     Arguments
     ----------
-    path : str
+    config_file_path : str
         Main path
 
     Return
     ------
-    out_dict : dict
-        Data container containing dics
+    dict
+        Dictionary containing the paths to each datafile
     """
-    paths = {
-        'path_main': path,
-
+    paths = [
+        'path_main',
         # Path to all technologies
-        'path_technologies': os.path.join(
-            path, '05-technologies', 'technology_definition.csv'),
-
+        'path_technologies',
         # Paths to fuel raw data
-        'rs_fuel_raw': os.path.join(
-            path, '02-fuel_base_year', 'rs_fuel.csv'),
-        'ss_fuel_raw': os.path.join(
-            path, '02-fuel_base_year', 'ss_fuel.csv'),
-        'is_fuel_raw': os.path.join(
-            path, '02-fuel_base_year', 'is_fuel.csv'),
-
+        'rs_fuel_raw',
+        'ss_fuel_raw',
+        'is_fuel_raw',
         # Load profiles
-        'lp_rs': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'HES_lp.csv'),
-
+        'lp_rs',
         # Technologies load shapes
-        'path_hourly_gas_shape_resid': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'lp_gas_boiler_dh_SANSOM.csv'),
-        'lp_elec_hp_dh': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'lp_elec_hp_dh_LOVE.csv'),
-        'lp_all_microCHP_dh': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'lp_all_microCHP_dh_SANSOM.csv'),
-        'path_shape_rs_cooling': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'shape_residential_cooling.csv'),
-        'path_shape_ss_cooling': os.path.join(
-            path, '03-load_profiles', 'ss_submodel', 'shape_service_cooling.csv'),
-        'lp_elec_storage_heating': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'lp_elec_storage_heating_HESReport.csv'),
-        'lp_elec_secondary_heating': os.path.join(
-            path, '03-load_profiles', 'rs_submodel', 'lp_elec_secondary_heating_HES.csv'),
-
+        'path_hourly_gas_shape_resid',
+        'lp_elec_hp_dh',
+        'lp_all_microCHP_dh',
+        'path_shape_rs_cooling',
+        'path_shape_ss_cooling',
+        'lp_elec_storage_heating',
+        'lp_elec_secondary_heating',
         # Census data
-        'path_employment_statistics': os.path.join(
-            path, '04-census_data', 'LAD_census_data.csv'),
-
+        'path_employment_statistics',
         # Validation datasets
-        'val_subnational_elec': os.path.join(
-            path, '01-validation_datasets', '02_subnational_elec', 'data_2015_elec.csv'),
-        'val_subnational_elec_residential': os.path.join(
-            path, '01-validation_datasets', '02_subnational_elec', 'data_2015_elec_domestic.csv'),
-        'val_subnational_elec_non_residential': os.path.join(
-            path, '01-validation_datasets', '02_subnational_elec', 'data_2015_elec_non_domestic.csv'),
-        'val_subnational_elec_msoa_residential': os.path.join(
-            path, '01-validation_datasets', '02_subnational_elec', 'MSOA_domestic_electricity_2015_cleaned.csv'),
-        'val_subnational_elec_msoa_non_residential': os.path.join(
-            path, '01-validation_datasets', '02_subnational_elec', 'MSOA_non_dom_electricity_2015_cleaned.csv'),
-        'val_subnational_gas': os.path.join(
-            path, '01-validation_datasets', '03_subnational_gas', 'data_2015_gas.csv'),
-        'val_subnational_gas_residential': os.path.join(
-            path, '01-validation_datasets', '03_subnational_gas', 'data_2015_gas_domestic.csv'),
-        'val_subnational_gas_non_residential': os.path.join(
-            path, '01-validation_datasets', '03_subnational_gas', 'data_2015_gas_non_domestic.csv'),
-        'val_nat_elec_data': os.path.join(
-            path, '01-validation_datasets', '01_national_elec_2015', 'elec_demand_2015.csv')}
+        'val_subnational_elec',
+        'val_subnational_elec_residential',
+        'val_subnational_elec_non_residential',
+        'val_subnational_elec_msoa_residential',
+        'val_subnational_elec_msoa_non_residential',
+        'val_subnational_gas',
+        'val_subnational_gas_residential',
+        'val_subnational_gas_non_residential',
+        'val_nat_elec_data']
 
-    return paths
+    return _read_config_file_section('CONFIG_DATA', config_file_path, paths)
 
 def load_tech_profiles(
         tech_lp,

--- a/energy_demand/read_write/data_loader.py
+++ b/energy_demand/read_write/data_loader.py
@@ -595,6 +595,32 @@ def _read_config_file_section(section, config_file_path, items):
     return data_paths
 
 
+def get_weather_result_paths(weather_path):
+    """Joins results subfolders to ``weather_path`` and returns a dict
+
+    Arguments
+    ---------
+    weather_path : str
+        Path to the weather results simulations
+
+    Returns
+    -------
+    dict
+    """
+    paths = {
+        'data_results':
+            weather_path,
+        'data_results_PDF': os.path.join(
+            weather_path, 'PDF_results'),
+        'data_results_validation': os.path.join(
+            weather_path, 'PDF_validation'),
+        'data_results_model_runs': os.path.join(
+            weather_path, 'model_run_results_txt'),
+        }
+
+    return paths
+
+
 def get_result_paths(config_file_path):
     """Load all result paths
 
@@ -1193,6 +1219,7 @@ def rs_collect_shapes_from_txts(txt_path, model_yeardays):
             'shape_non_peak_yd': shape_non_peak_yd_selection}
 
     return rs_shapes_dh, rs_shapes_yd
+
 
 def ss_collect_shapes_from_txts(txt_path, model_yeardays):
     """Collect service shapes from txt files for every setor and enduse

--- a/energy_demand/scripts/s_post_installation.py
+++ b/energy_demand/scripts/s_post_installation.py
@@ -31,18 +31,15 @@ def post_install_setup(args):
 
     path_config_file = args.local_data
 
-    config = configparser.ConfigParser()
-    config.read(path_config_file)
-    config = basic_functions.convert_config_to_correct_type(config)
+    config = data_loader.read_config_file(path_config_file)
     local_data_path = config['PATHS']['path_local_data']
-    path_results = config['PATHS']['path_result_data']
 
     base_yr = config['CONFIG']['base_yr']
 
     data = {}
-    data['paths'] = data_loader.load_paths(path_config_file)
-    data['local_paths'] = data_loader.get_local_paths(path_config_file)
-    data['result_paths'] = data_loader.get_result_paths(path_results)
+    data['paths'] = config['CONFIG_DATA']
+    data['local_paths'] = config['DATA_PATHS']
+    data['result_paths'] = config['RESULT_DATA']
     data['lookups'] = lookup_tables.basic_lookups()
     data['enduses'], data['sectors'], data['fuels'], lookup_enduses, \
         lookup_sector_enduses = data_loader.load_fuels(data['paths'])

--- a/energy_demand/scripts/s_post_installation.py
+++ b/energy_demand/scripts/s_post_installation.py
@@ -6,8 +6,6 @@ Script function which are executed after model installation and
 import os
 import zipfile
 import configparser
-from pkg_resources import Requirement
-from pkg_resources import resource_filename
 
 from energy_demand.basic import basic_functions
 from energy_demand.assumptions import general_assumptions
@@ -16,6 +14,7 @@ from energy_demand.scripts import s_ss_raw_shapes
 from energy_demand.read_write import data_loader
 from energy_demand.basic import lookup_tables
 from energy_demand.scripts.smif_data_related import script_data_preparation_MISTRAL_pop_gva
+
 
 def post_install_setup(args):
     """Run this function after installing the energy_demand
@@ -30,30 +29,23 @@ def post_install_setup(args):
     """
     print("... start running initialisation scripts", flush=True)
 
-    path_main = resource_filename(
-        Requirement.parse("energy_demand"),
-        os.path.join("energy_demand", "config_data"))
-
-    path_config_file = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__), '..', '..', '..', 'config', 'wrapperconfig.ini'))
-
-    path_results = resource_filename(Requirement.parse("energy_demand"), "results")
-    local_data_path = args.local_data
+    path_config_file = args.local_data
 
     config = configparser.ConfigParser()
     config.read(path_config_file)
     config = basic_functions.convert_config_to_correct_type(config)
+    local_data_path = config['PATHS']['path_local_data']
+    path_results = config['PATHS']['path_result_data']
 
     base_yr = config['CONFIG']['base_yr']
 
     data = {}
-    data['paths'] = data_loader.load_paths(path_main)
-    data['local_paths'] = data_loader.get_local_paths(local_data_path)
+    data['paths'] = data_loader.load_paths(path_config_file)
+    data['local_paths'] = data_loader.get_local_paths(path_config_file)
     data['result_paths'] = data_loader.get_result_paths(path_results)
     data['lookups'] = lookup_tables.basic_lookups()
-    data['enduses'], data['sectors'], data['fuels'], lookup_enduses, lookup_sector_enduses = data_loader.load_fuels(
-        paths=data['paths'])
+    data['enduses'], data['sectors'], data['fuels'], lookup_enduses, \
+        lookup_sector_enduses = data_loader.load_fuels(data['paths'])
 
     data['assumptions'] = general_assumptions.Assumptions(
         lookup_enduses=lookup_enduses,
@@ -95,7 +87,8 @@ def post_install_setup(args):
     print("Generate additional data", flush=True)
 
     # Extract NISMOD population data
-    path_to_zip_file = os.path.join(local_data_path, "population-economic-smif-csv-from-nismod-db.zip")
+    path_to_zip_file = os.path.join(local_data_path,
+                                    "population-economic-smif-csv-from-nismod-db.zip")
     path_extraction = os.path.join(local_data_path, 'scenarios', "MISTRAL_pop_gva")
     zip_ref = zipfile.ZipFile(path_to_zip_file, 'r')
     zip_ref.extractall(path_extraction)
@@ -103,8 +96,9 @@ def post_install_setup(args):
 
     # Complete gva and pop data for every sector
     data_pop = os.path.join(local_data_path, "scenarios", "MISTRAL_pop_gva", "data")
-    path_geography = os.path.join(local_data_path, "scenarios", "uk_pop_principal_2015_2050_MSOA_england.csv")
-    geography_name = "region" # "lad_uk_2016"
+    path_geography = os.path.join(local_data_path, "scenarios",
+                                  "uk_pop_principal_2015_2050_MSOA_england.csv")
+    geography_name = "region"  # "lad_uk_2016"
 
     script_data_preparation_MISTRAL_pop_gva.run(
         path_to_folder=data_pop,
@@ -115,11 +109,13 @@ def post_install_setup(args):
     print("... successfully finished setup")
     return
 
+
 '''
 local_data_path = "C:/Users/cenv0553/ed/data"
 # Complete gva and pop data for every sector
 data_pop = os.path.join(local_data_path, "scenarios", "MISTRAL_pop_gva_TEST", "data")
-path_geography = os.path.join(local_data_path, "scenarios", "uk_pop_principal_2015_2050_MSOA_england.csv")
+path_geography = os.path.join(local_data_path, "scenarios",
+                              "uk_pop_principal_2015_2050_MSOA_england.csv")
 geography_name = "region" # "lad_uk_2016"
 
 script_data_preparation_MISTRAL_pop_gva.run(

--- a/energy_demand/scripts/s_write_dummy_data.py
+++ b/energy_demand/scripts/s_write_dummy_data.py
@@ -115,7 +115,7 @@ def post_install_setup_minimum(args):
     base_yr = 2015
     data = {}
 
-    data['paths'] = data_loader.load_paths(path_energy_demand)
+    data['paths'] = data_loader.load_paths(path_config_file)
 
     data['lookups'] = lookup_tables.basic_lookups()
 
@@ -143,6 +143,6 @@ def post_install_setup_minimum(args):
     # Dummy service sector load profiles
     # --------
     dummy_sectoral_load_profiles(
-        local_paths, path_energy_demand)
+        local_paths, path_config_file)
 
     print("Successfully finished post installation setup with open source data")

--- a/energy_demand/scripts/s_write_dummy_data.py
+++ b/energy_demand/scripts/s_write_dummy_data.py
@@ -74,16 +74,18 @@ def post_install_setup_minimum(args):
     path_energy_demand : str
         Path to energy demand python files
     """
-    path_energy_demand = resource_filename(
-        Requirement.parse("energy_demand"),
-        os.path.join("energy_demand", "config_data"))
+    path_config_file = args.local_data
+    config = configparser.ConfigParser()
+    success = config.read(path_config_file)
+    if not success:
+        msg = "Unable to read configuration file at path {}"
+        raise RuntimeError(msg.format(path_config_file))
 
-    path_local_data = args.local_data
+    # Save config in dict and get correct type
+    config = basic_functions.convert_config_to_correct_type(config)
 
-    path_config_file = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__), '..', '..', '..', 'config', 'wrapperconfig.ini'))
-            #os.path.dirname(__file__), '..', '..', '..', 'models', 'energy_demand', 'wrapperconfig.ini'))
+    path_energy_demand = config['PATHS']['path_config_data']
+    path_local_data = config['PATHS']['path_local_data']
 
     # Get config in dict and get correct type
     config = configparser.ConfigParser()
@@ -96,11 +98,11 @@ def post_install_setup_minimum(args):
     print("... running initialisation scripts with only publicly available data")
 
     # Load paths
-    local_paths = data_loader.get_local_paths(path_local_data)
+    local_paths = data_loader.get_local_paths(args.local_data)
 
     # Create folders to input data
-    raw_folder = os.path.join(path_local_data, 'energy_demand', '_raw_data')
-    processed_folder = os.path.join(path_local_data, 'energy_demand', '_processed_data')
+    raw_folder = os.path.join(path_local_data, '_raw_data')
+    processed_folder = os.path.join(path_local_data, '_processed_data')
 
     basic_functions.create_folder(raw_folder)
     basic_functions.create_folder(processed_folder)
@@ -116,6 +118,7 @@ def post_install_setup_minimum(args):
     data['paths'] = data_loader.load_paths(path_energy_demand)
 
     data['lookups'] = lookup_tables.basic_lookups()
+
     data['enduses'], data['sectors'], data['fuels'], lookup_enduses, lookup_sector_enduses = data_loader.load_fuels(data['paths'])
 
     # Assumptions

--- a/energy_demand/scripts/smif_data_related/script_data_preparation_MISTRAL_pop_gva.py
+++ b/energy_demand/scripts/smif_data_related/script_data_preparation_MISTRAL_pop_gva.py
@@ -8,12 +8,13 @@ import numpy as np
 from energy_demand.basic import lookup_tables
 from energy_demand.basic import basic_functions
 
+
 def run(
         path_to_folder,
         path_MSOA_baseline,
         MSOA_calculations=False,
         geography_name='region'
-    ):
+        ):
     """
     path_to_folder : str
         Path to data folder

--- a/energy_demand/wrapper_model.py
+++ b/energy_demand/wrapper_model.py
@@ -28,9 +28,9 @@ def load_data_before_simulation(
     # -----------
     base_yr = config['CONFIG']['base_yr']
     weather_yr_scenario = config['CONFIG']['weather_yr_scenario']
-    path_new_scenario = data['path_new_scenario']
+    path_new_scenario = config['PATHS']['path_new_scenario']
 
-    data['weather_station_count_nr'] = [] # Default value is '[]' to use all stations
+    data['weather_station_count_nr'] = []  # Default value is '[]' to use all stations
     data['data_path'] = os.path.normpath(config['PATHS']['path_local_data'])
     data['processed_path'] = os.path.normpath(config['PATHS']['path_processed_data'])
     data['result_path'] = os.path.normpath(config['PATHS']['path_result_data'])
@@ -104,7 +104,7 @@ def load_data_before_simulation(
 
     # Create .ini file with simulation parameter
     write_data.write_simulation_inifile(
-        data['path_new_scenario'], data, region_selection)
+        path_new_scenario, data, region_selection)
 
     # -------------------------------------------
     # Weather year specific initialisations
@@ -112,14 +112,14 @@ def load_data_before_simulation(
     path_folder_weather_yr = os.path.join(
         os.path.join(path_new_scenario, data['simulation_name']))
 
-    data['result_paths'] = data_loader.get_result_paths(path_folder_weather_yr)
+    data['weather_result_paths'] = data_loader.get_weather_result_paths(path_folder_weather_yr)
 
     folders_to_create = [
         path_folder_weather_yr,
-        data['result_paths']['data_results'],
-        data['result_paths']['data_results_PDF'],
-        data['result_paths']['data_results_validation'],
-        data['result_paths']['data_results_model_runs']]
+        data['weather_result_paths']['data_results'],
+        data['weather_result_paths']['data_results_PDF'],
+        data['weather_result_paths']['data_results_validation'],
+        data['weather_result_paths']['data_results_model_runs']]
     for folder in folders_to_create:
         basic_functions.create_folder(folder)
 

--- a/energy_demand/wrapper_model.py
+++ b/energy_demand/wrapper_model.py
@@ -34,17 +34,16 @@ def load_data_before_simulation(
     data['data_path'] = os.path.normpath(config['PATHS']['path_local_data'])
     data['processed_path'] = os.path.normpath(config['PATHS']['path_processed_data'])
     data['result_path'] = os.path.normpath(config['PATHS']['path_result_data'])
-    data['paths'] = data_loader.load_paths(config['PATHS']['path_config_data'])
+    data['paths'] = config['CONFIG_DATA']
 
     # Downloaded (FTP) data
-    data['local_paths'] = data_loader.get_local_paths(
-        data['data_path'])
+    data['local_paths'] = config['DATA_PATHS']
 
     # ------------------------------------------------
     # Load Inputs
     # ------------------------------------------------
-    data['enduses'], data['sectors'], data['fuels'], lookup_enduses, lookup_sector_enduses = data_loader.load_fuels(
-        data['paths'])
+    data['enduses'], data['sectors'], data['fuels'], lookup_enduses, \
+        lookup_sector_enduses = data_loader.load_fuels(data['paths'])
 
     # ------------------------------------------------
     # Load Assumptions

--- a/energy_demand/wrapper_model.py
+++ b/energy_demand/wrapper_model.py
@@ -43,7 +43,7 @@ def load_data_before_simulation(
     # Load Inputs
     # ------------------------------------------------
     data['enduses'], data['sectors'], data['fuels'], lookup_enduses, \
-        lookup_sector_enduses = data_loader.load_fuels(data['paths'])
+        lookup_sector_enduses = data_loader.load_fuels(config['CONFIG_DATA'])
 
     # ------------------------------------------------
     # Load Assumptions
@@ -56,7 +56,7 @@ def load_data_before_simulation(
         simulation_end_yr=config['CONFIG']['user_defined_simulation_end_yr'],
         curr_yr=curr_yr,
         sim_yrs=sim_yrs,
-        paths=data['paths'],
+        paths=config['CONFIG_DATA'],
         enduses=data['enduses'],
         sectors=data['sectors'],
         reg_nrs=len(data['regions']))
@@ -94,7 +94,7 @@ def load_data_before_simulation(
     if config['CRITERIA']['reg_selection']:
         
         region_selection = read_data.get_region_selection(
-            os.path.join(data['local_paths']['local_path_datafolder'],
+            os.path.join(config['DATA_PATHS']['local_path_datafolder'],
             "region_definitions",
             config['CRITERIA']['reg_selection_csv_name']))
         #region_selection = ['E02003237', 'E02003238']
@@ -127,16 +127,16 @@ def load_data_before_simulation(
     # Load load profiles of technologies
     # ------------------------------------------------
     data['tech_lp'] = data_loader.load_data_profiles(
-        data['paths'],
-        data['local_paths'],
+        config['CONFIG_DATA'],
+        config['DATA_PATHS'],
         data['assumptions'].model_yeardays,
         data['assumptions'].model_yeardays_daytype)
 
     # Obtain population data for disaggregation
     if config['CRITERIA']['msoa_crit']:
-        name_population_dataset = data['local_paths']['path_population_data_for_disaggregation_MSOA']
+        name_population_dataset = config['CONFIG_DATA']['path_population_data_for_disaggregation_msoa']
     else:
-        name_population_dataset = data['local_paths']['path_population_data_for_disaggregation_LAD']
+        name_population_dataset = config['CONFIG_DATA']['path_population_data_for_disaggregation_lad']
     data['pop_for_disag'] = data_loader.read_scenario_data(name_population_dataset)
 
     # ------------------------------------------------
@@ -146,7 +146,7 @@ def load_data_before_simulation(
         data['scenario_data']['floor_area']['rs_floorarea'], data['scenario_data']['floor_area']['ss_floorarea'], data['service_building_count'], rs_regions_without_floorarea, ss_regions_without_floorarea = data_loader.floor_area_virtual_dw(
             data['regions'],
             data['sectors'],
-            data['local_paths'],
+            config['CONFIG_DATA'],
             data['scenario_data']['population'][data['assumptions'].base_yr],
             base_yr=data['assumptions'].base_yr)
 
@@ -397,4 +397,4 @@ def plots(
             data['weather_stations'],
             os.path.join(data['result_path'], 'weatherst_distr_weathyr_{}.pdf'.format(
                 config['CONFIG']['weather_yr_scenario'])),
-            path_shapefile=data['local_paths']['lad_shapefile'])
+            path_shapefile=config['DATA_PATHS']['lad_shapefile'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,7 @@ addopts = tests
 # Specify command line options as you would do when invoking py.test directly.
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
-addopts =
-    --cov energy_demand --cov-report term-missing
-    --verbose
+# addopts = 
 
 norecursedirs =
     dist

--- a/tests/read_write/data_loader.py
+++ b/tests/read_write/data_loader.py
@@ -1,3 +1,0 @@
-"""
-"""
-from energy_demand.read_write import read_data

--- a/tests/read_write/test_data_loader.py
+++ b/tests/read_write/test_data_loader.py
@@ -1,0 +1,79 @@
+"""
+"""
+from pytest import fixture
+from unittest.mock import Mock
+from energy_demand.read_write.data_loader import get_local_paths
+
+
+@fixture(scope='function')
+def config_file(tmpdir):
+
+    config_file = tmpdir.mkdir("config").join("wrapperconfig.ini")
+    content = \
+"""
+[PATHS]
+path_local_data = /vagrant/data/energy_demand
+path_processed_data = /vagrant/data/energy_demand/_processed_data
+path_result_data = /vagrant/data/energy_demand/results
+path_config_data = /vagrant/data/energy_demand/config_data
+
+[CONFIG]
+base_yr = 2015
+weather_yr_scenario = 2015
+user_defined_simulation_end_yr = 2050
+user_defined_weather_by = 2015
+
+[CRITERIA]
+mode_constrained = True
+virtual_building_stock_criteria = True
+write_out_national = False
+reg_selection = False
+MSOA_crit = False
+reg_selection_csv_name = msoa_regions_ed.csv
+spatial_calibration = False
+cluster_calc = False
+write_txt_additional_results = True
+validation_criteria = True
+plot_crit = False
+crit_plot_enduse_lp = False
+writeYAML_keynames = True
+writeYAML = False
+crit_temp_min_max = False
+
+[DATA_PATHS]
+local_path_datafolder = /vagrant/data/energy_demand
+path_strategy_vars =  /vagrant/data/energy_demand/energy_demand_minimal/00_user_defined_variables
+#ONS principal projection
+path_population_data_for_disaggregation_LAD =  /vagrant/data/energy_demand/energy_demand_minimal/_raw_data/J-population_disagg_by/uk_pop_principal_2015_2050.csv  
+#ONS principal projection
+folder_raw_carbon_trust = /vagrant/data/energy_demand/energy_demand_minimal/_raw_data/G_Carbon_Trust_advanced_metering_trial/
+path_population_data_for_disaggregation_MSOA = /vagrant/data/energy_demand/energy_demand_minimal/_raw_data/J-population_disagg_by/uk_pop_principal_2015_2050_MSOA_lad.csv
+folder_path_weater_stations = /vagrant/data/energy_demand/energy_demand_minimal/_raw_data/A-temperature_data/cleaned_weather_stations.csv
+path_floor_area_virtual_stock_by = /vagrant/data/energy_demand/energy_demand_minimal/_raw_data/K-floor_area/floor_area_LAD_latest.csv
+path_assumptions_db = /vagrant/data/energy_demand/_processed_data/assumptions_from_db
+data_processed = /vagrant/data/energy_demand/_processed_data
+lad_shapefile = /vagrant/data/energy_demand/energy_demand_minimal/_raw_data/C_LAD_geography/same_as_pop_scenario/lad_2016_uk_simplified.shp
+path_post_installation_data = /vagrant/data/energy_demand/_processed_data
+weather_data = _/raw_data/A-temperature_data/cleaned_weather_stations_data
+load_profiles = /vagrant/data/energy_demand/_processed_data/load_profiles
+rs_load_profile_txt = /vagrant/data/energy_demand/_processed_data/load_profiles/rs_submodel),
+ss_load_profile_txt = /vagrant/data/energy_demand/_processed_data/load_profiles/ss_submodel),
+yaml_parameters = /vagrant/data/energy_demand/config/yaml_parameters.yml
+yaml_parameters_constrained = /vagrant/data/energy_demand/config/yaml_parameters_constrained.yml
+yaml_parameters_keynames_constrained = /vagrant/data/energy_demand/config/yaml_parameters_keynames_constrained.yml
+yaml_parameters_keynames_unconstrained = /vagrant/data/energy_demand/config/yaml_parameters_keynames_unconstrained.yml
+yaml_parameters_scenario = /vagrant/data/energy_demand/config/yaml_parameters_scenario.yml
+
+"""
+
+    config_file.write(content)
+
+    return config_file
+
+
+def test_get_local_paths(config_file):
+
+    actual = get_local_paths(config_file)
+
+    assert isinstance(actual, dict)
+    assert actual['yaml_parameters_scenario'] == '/vagrant/data/energy_demand/config/yaml_parameters_scenario.yml'


### PR DESCRIPTION
Fixes #144, but *currently breaks running the energy demand model*

The overall aim of these commits are to create a single source of truth - i.e. a config file - which contains all paths to the data source. Ultimately, this could avoid the need to pass dicts of paths around, which should simplify the code. @tomalrussell if you have any advice here, please let us know.

Requires a `wrapperconfig.ini` file which looks something like this:

```
[PATHS]
path_local_data = /vagrant/data/energy_demand
path_processed_data = /vagrant/data/energy_demand/_processed_data
path_result_data = /vagrant/data/energy_demand/results
path_config_data = /vagrant/data/energy_demand/config_data

[CONFIG]
base_yr = 2015
weather_yr_scenario = 2015
user_defined_simulation_end_yr = 2050
user_defined_weather_by = 2015

[CRITERIA]
mode_constrained = True
virtual_building_stock_criteria = True
write_out_national = False
reg_selection = False
MSOA_crit = False
reg_selection_csv_name = msoa_regions_ed.csv
spatial_calibration = False
cluster_calc = False
write_txt_additional_results = True
validation_criteria = True
plot_crit = False
crit_plot_enduse_lp = False
writeYAML_keynames = True
writeYAML = False
crit_temp_min_max = False

[DATA_PATHS]
local_path_datafolder = /vagrant/data/energy_demand/energy_demand
path_strategy_vars =  /vagrant/data/energy_demand/energy_demand/00_user_defined_variables
#ONS principal projection
path_population_data_for_disaggregation_LAD =  /vagrant/data/energy_demand/energy_demand/_raw_data/J-population_disagg_by/uk_pop_principal_2015_2050.csv  
#ONS principal projection
folder_raw_carbon_trust = /vagrant/data/energy_demand/energy_demand/_raw_data/G_Carbon_Trust_advanced_metering_trial/
path_population_data_for_disaggregation_MSOA = /vagrant/data/energy_demand/energy_demand/_raw_data/J-population_disagg_by/uk_pop_principal_2015_2050_MSOA_lad.csv
folder_path_weater_stations = /vagrant/data/energy_demand/energy_demand/_raw_data/A-temperature_data/cleaned_weather_stations.csv
path_floor_area_virtual_stock_by = /vagrant/data/energy_demand/energy_demand/_raw_data/K-floor_area/floor_area_LAD_latest.csv
path_assumptions_db = /vagrant/data/energy_demand/_processed_data/assumptions_from_db
data_processed = /vagrant/data/energy_demand/_processed_data
lad_shapefile = /vagrant/data/energy_demand/energy_demand/_raw_data/C_LAD_geography/same_as_pop_scenario/lad_2016_uk_simplified.shp
path_post_installation_data = /vagrant/data/energy_demand/_processed_data
weather_data = _/raw_data/A-temperature_data/cleaned_weather_stations_data
load_profiles = /vagrant/data/energy_demand/_processed_data/load_profiles
rs_load_profile_txt = /vagrant/data/energy_demand/_processed_data/load_profiles/rs_submodel
ss_load_profile_txt = /vagrant/data/energy_demand/_processed_data/load_profiles/ss_submodel
yaml_parameters = /vagrant/data/energy_demand/config/yaml_parameters.yml
yaml_parameters_constrained = /vagrant/data/energy_demand/config/yaml_parameters_constrained.yml
yaml_parameters_keynames_constrained = /vagrant/data/energy_demand/config/yaml_parameters_keynames_constrained.yml
yaml_parameters_keynames_unconstrained = /vagrant/data/energy_demand/config/yaml_parameters_keynames_unconstrained.yml
yaml_parameters_scenario = /vagrant/data/energy_demand/config/yaml_parameters_scenario.yml

[CONFIG_DATA]
path_main = /vagrant/data/energy_demand/config_data
# Path to all technologies
path_technologies = /vagrant/data/energy_demand/config_data/05-technologies/technology_definition.csv
# Paths to fuel raw data
rs_fuel_raw = /vagrant/data/energy_demand/config_data/02-fuel_base_year/rs_fuel.csv
ss_fuel_raw = /vagrant/data/energy_demand/config_data/02-fuel_base_year/ss_fuel.csv
is_fuel_raw = /vagrant/data/energy_demand/config_data/02-fuel_base_year/is_fuel.csv
# Load profiles
lp_rs = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/HES_lp.csv
# Technologies load shapes
path_hourly_gas_shape_resid = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/lp_gas_boiler_dh_SANSOM.csv
lp_elec_hp_dh = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/lp_elec_hp_dh_LOVE.csv
lp_all_microCHP_dh = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/lp_all_microCHP_dh_SANSOM.csv
path_shape_rs_cooling = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/shape_residential_cooling.csv
path_shape_ss_cooling = /vagrant/data/energy_demand/config_data/03-load_profiles/ss_submodel/shape_service_cooling.csv
lp_elec_storage_heating = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/lp_elec_storage_heating_HESReport.csv
lp_elec_secondary_heating = /vagrant/data/energy_demand/config_data/03-load_profiles/rs_submodel/lp_elec_secondary_heating_HES.csv
# Census data
path_employment_statistics = /vagrant/data/energy_demand/config_data/04-census_data/LAD_census_data.csv
# Validation datasets
val_subnational_elec = /vagrant/data/energy_demand/config_data/01-validation_datasets/02_subnational_elec/data_2015_elec.csv
val_subnational_elec_residential = /vagrant/data/energy_demand/config_data/01-validation_datasets/02_subnational_elec/data_2015_elec_domestic.csv
val_subnational_elec_non_residential = /vagrant/data/energy_demand/config_data/01-validation_datasets/02_subnational_elec/data_2015_elec_non_domestic.csv
val_subnational_elec_msoa_residential = /vagrant/data/energy_demand/config_data/01-validation_datasets/02_subnational_elec/MSOA_domestic_electricity_2015_cleaned.csv
val_subnational_elec_msoa_non_residential = /vagrant/data/energy_demand/config_data/01-validation_datasets/02_subnational_elec/MSOA_non_dom_electricity_2015_cleaned.csv
val_subnational_gas = /vagrant/data/energy_demand/config_data/01-validation_datasets/03_subnational_gas/data_2015_gas.csv
val_subnational_gas_residential = /vagrant/data/energy_demand/config_data/01-validation_datasets/03_subnational_gas/data_2015_gas_domestic.csv
val_subnational_gas_non_residential = /vagrant/data/energy_demand/config_data/01-validation_datasets/03_subnational_gas/data_2015_gas_non_domestic.csv
val_nat_elec_data = /vagrant/data/energy_demand/config_data/01-validation_datasets/01_national_elec_2015/elec_demand_2015.csv)}
```

## Notes

- keys in the config file are stored in lower case, which means that getting `lp_all_microCHP_dh` results in an error, but `lp_all_microchp_dh` works fine.